### PR TITLE
Fix pheno selection for association

### DIFF
--- a/GWASSER.R
+++ b/GWASSER.R
@@ -333,7 +333,7 @@ if(!interactive()){
       message(paste0("Starting association of SNPs for phenotype: ", pheno))
 
       results <- snpAssociation(df = combined$data,
-                               phenotype = args$pheno,
+                               phenotype = pheno,
                                covs = args$covs,
                                start = combined$IDcol + 1)
       output <- data.frame(ID = names(results[[1]]), fvalues = results[[1]], minlogp = results[[2]])


### PR DESCRIPTION
Fixes a bug which causes data for the first phenotype/trait to be used for all phenotypes specified on the command-line.