### PR TITLE
Get rid of unexpected "ID.1" column appearing after data file merge

### DIFF
--- a/GWASSER.R
+++ b/GWASSER.R
@@ -204,7 +204,9 @@ mergeGenoPheno <- function(pheno, geno){
   namesNotID <- function(table, before = FALSE){
     cnames <- colnames(table)
     idcol <- which(cnames == "ID")
-    if(before){
+    if (before && idcol == 1) {
+      out <- NULL
+    } else if (before) {
       out <- cnames[1:(idcol - 1)]
     } else {
       out <- cnames[(idcol + 1):ncol(table)]


### PR DESCRIPTION
A duplicate of ID column named "ID.1" appears after merging data files and propagates to result files. This PR gets rid of that column.